### PR TITLE
Improve tick format handling

### DIFF
--- a/client/src/components/app/OptimizationsPage.vue
+++ b/client/src/components/app/OptimizationsPage.vue
@@ -158,6 +158,7 @@ Last update: 2018-08-02
           {x: FLOAT_FORMATTER, xTicks: 6, y: SI_FORMATTER, yTicks: null},
           {x: FLOAT_FORMATTER, xTicks: 6, y: SI_FORMATTER, yTicks: null},
         ],
+        defaultFormatter: {x: FLOAT_FORMATTER, xTicks: null, y: SI_FORMATTER, yTicks: null},
       }
     },
 
@@ -406,15 +407,19 @@ Last update: 2018-08-02
               while (div.firstChild) {
                 div.removeChild(div.firstChild);
               }
-              try {  
-                mpld3.draw_figure(divlabel, response.data.graphs[index], (fig, element) => {
-                  const formatters = this.graphFormatters[index];
+              try {
+                mpld3.draw_figure(divlabel, response.data.result.graphs[index], (fig, element) => {
+                  var formatters = this.defaultFormatter
+                  if (index<this.graphFormatters.length) {
+                    formatters = this.graphFormatters[index];
+                  }
                   fig.setXTicks(formatters.xTicks, formatters.x);
                   fig.setYTicks(formatters.yTicks, formatters.y);
                 });
               }
               catch (err) {
-                console.log('failled:' + err.message);
+                console.log('Graphs failed:' + err.message);
+                status.fail(this, 'Error creating graphs: ' + err.message)
               }
             }
             

--- a/client/src/components/app/ScenariosPage.vue
+++ b/client/src/components/app/ScenariosPage.vue
@@ -171,6 +171,7 @@ Last update: 2018-08-02
           {x: FLOAT_FORMATTER, xTicks: 6, y: SI_FORMATTER, yTicks: null},
           {x: FLOAT_FORMATTER, xTicks: 6, y: SI_FORMATTER, yTicks: null},
         ],
+        defaultFormatter: {x: FLOAT_FORMATTER, xTicks: null, y: SI_FORMATTER, yTicks: null},
       }
     },
 
@@ -417,13 +418,17 @@ Last update: 2018-08-02
               }
               try {
                 mpld3.draw_figure(divlabel, response.data.graphs[index], (fig, element) => {
-                  const formatters = this.graphFormatters[index];
+                  var formatters = this.defaultFormatter
+                  if (index<this.graphFormatters.length) {
+                    formatters = this.graphFormatters[index];
+                  }
                   fig.setXTicks(formatters.xTicks, formatters.x);
                   fig.setYTicks(formatters.yTicks, formatters.y);
                 });
               }
               catch (err) {
-                console.log('failled:' + err.message);
+                console.log('graphs failed failed:' + err.message);
+                status.fail(this, 'Error creating graphs: ' + err.message)
               }
             }
             

--- a/nutrition/plotting.py
+++ b/nutrition/plotting.py
@@ -71,7 +71,7 @@ def plot_prevs(all_res):
             leglabels.append(res.name)
         # formatting
         sc.SIticks(ax=ax, axis='y')
-        ax.set_ylabel('Percentage')
+#        ax.set_ylabel('Percentage') # Shown as tick labels
         ax.set_ylim([0, ymax + ymax*0.1])
         ax.set_xlabel('Years')
         ax.set_title(utils.relabel(prev))


### PR DESCRIPTION
I've added a place to specify formats for each graph, so that we can do this in the component without resorting to hacks. The only disadvantage is that we have to maintain an array of the correct length, with the formats for the graphs.

I couldn't test this for the Optimizations page, so if you could do that @cliffckerr that would be great…