### PR TITLE
Fix optimization export data

### DIFF
--- a/client/src/app/OptimizationsPage.vue
+++ b/client/src/app/OptimizationsPage.vue
@@ -68,7 +68,7 @@ Last update: 2018sep25
           <button class="btn btn-icon" @click="scaleFigs(1.0)" data-tooltip="Reset zoom"><i class="ti-zoom-in"></i></button>
           <button class="btn btn-icon" @click="scaleFigs(1.1)" data-tooltip="Zoom in">+</button>
           &nbsp;&nbsp;&nbsp;
-          <!--<button class="btn" @click="exportGraphs()">Export plots</button>-->
+          <button class="btn" @click="exportGraphs(projectID, displayResultDatastoreId)">Export plots</button>
           <button class="btn" @click="exportResults(projectID, displayResultDatastoreId)">Export data</button>
         </div>
       </div>
@@ -264,7 +264,7 @@ Last update: 2018sep25
 
       clearGraphs()                       { return utils.clearGraphs() },
       makeGraphs(graphdata)               { return utils.makeGraphs(this, graphdata) },
-      exportGraphs(project_id)            { return utils.exportGraphs(this, project_id) },
+      exportGraphs(project_id, cache_id)  { return utils.exportGraphs(this, project_id, cache_id) },
       exportResults(project_id, cache_id) { return utils.exportResults(this, project_id, cache_id) },
 
       scaleFigs(frac) {

--- a/client/src/app/ScenariosPage.vue
+++ b/client/src/app/ScenariosPage.vue
@@ -64,7 +64,7 @@ Last update: 2018-09-25
           <button class="btn btn-icon" @click="scaleFigs(1.0)" data-tooltip="Reset zoom"><i class="ti-zoom-in"></i></button>
           <button class="btn btn-icon" @click="scaleFigs(1.1)" data-tooltip="Zoom in">+</button>
           &nbsp;&nbsp;&nbsp;
-          <button class="btn" @click="exportGraphs(projectID)">Export plots</button>
+          <button class="btn" @click="exportGraphs(projectID, 'scens')">Export plots</button>
           <button class="btn" @click="exportResults(projectID, 'scens')">Export results</button>
         </div>
       </div>
@@ -249,7 +249,7 @@ Last update: 2018-09-25
     methods: {
 
       makeGraphs(graphdata)               { return utils.makeGraphs(this, graphdata) },
-      exportGraphs(project_id)            { return utils.exportGraphs(this, project_id) },
+      exportGraphs(project_id, cache_id)  { return utils.exportGraphs(this, project_id, cache_id) },
       exportResults(project_id, cache_id) { return utils.exportResults(this, project_id, cache_id) },
                                 
       scaleFigs(frac) {

--- a/client/src/js/utils.js
+++ b/client/src/js/utils.js
@@ -111,7 +111,7 @@ function getPlotOptions(vm) {
       vm.plotOptions = response.data // Get the parameter values
     })
     .catch(error => {
-      status.failurePopup(vm, 'Could not get plot options: ' + error.message)
+      status.fail(vm, 'Could not get plot options', error)
     })
 }
 
@@ -166,11 +166,11 @@ function clearGraphs(vm, numfigs) {
   }
 }
 
-function exportGraphs(vm, project_id) {
+function exportGraphs(vm, project_id, cache_id) {
   console.log('exportGraphs() called')
-  rpcs.download('export_graphs', [project_id]) // Make the server call to download the framework to a .prj file.
+  rpcs.download('export_graphs', [project_id, cache_id]) // Make the server call to download the framework to a .prj file.
     .catch(error => {
-      status.failurePopup(vm, 'Could not download graphs: ' + error.message)
+      status.fail(vm, 'Could not download graphs', error)
     })
 }
 
@@ -178,7 +178,7 @@ function exportResults(vm, project_id, cache_id) {
   console.log('exportResults()')
   rpcs.download('export_results', [project_id, cache_id]) // Make the server call to download the framework to a .prj file.
     .catch(error => {
-      status.failurePopup(vm, 'Could not export results: ' + error.message)
+      status.fail(vm, 'Could not export results', error)
     })
 }
 

--- a/nutrition_app/rpcs.py
+++ b/nutrition_app/rpcs.py
@@ -940,12 +940,12 @@ def export_results(project_id, cache_id):
 
 
 @RPC(call_type='download')
-def export_graphs(project_id):
+def export_graphs(project_id, cache_id):
     proj = load_project(project_id, die=True) # Load the project with the matching UID.
     proj = retrieve_results(proj)
     file_name = '%s graphs.pdf' % proj.name # Create a filename containing the project name followed by a .prj suffix.
     full_file_name = get_path(file_name, proj.webapp.username) # Generate the full file name with path.
-    figs = proj.plot(-1) # Generate the plots
+    figs = proj.plot(key=cache_id) # Generate the plots
     sc.savefigs(figs, filetype='singlepdf', filename=full_file_name)
     print(">> export_graphs %s" % (full_file_name)) # Display the call information.
     return full_file_name # Return the full filename.


### PR DESCRIPTION
This PR has fixed `export_results()` so that the cache ID is used to pick the desired results out of the project.  So now, "Export data" works properly for both the Scenarios and Optimizations pages.