### PR TITLE
Fixed

### DIFF
--- a/client/src/app/InputsPage.vue
+++ b/client/src/app/InputsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Define health packages
 
-Last update: 2018-08-02
+Last update: 2018-10-03
 -->
 
 <template>
@@ -173,9 +173,9 @@ Last update: 2018-08-02
 
       uploadDatabook() {
         console.log('uploadDatabook() called')
-        status.start(this, 'Uploading databook...')
         rpcs.upload('upload_databook', [this.projectID], {}, '.xlsx')
           .then(response => {
+            status.start(this, 'Uploading databook...')
             this.getSheetData() // Refresh the table
             status.succeed(this, 'Data uploaded')
           })

--- a/client/src/app/ProjectsPage.vue
+++ b/client/src/app/ProjectsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Manage projects page
 
-Last update: 2018sep22
+Last update: 2018oct03
 -->
 
 <template>
@@ -449,9 +449,9 @@ Last update: 2018sep22
 
       uploadDatabook(uid) {
         console.log('uploadDatabook() called')
-        status.start(this, 'Uploading databook...')
         rpcs.upload('upload_databook', [uid], {}, '.xlsx')
           .then(response => {
+            status.start(this, 'Uploading databook...')
             this.updateProjectSummaries(uid) // Update the project summaries
             status.succeed(this, 'Data uploaded to project') // Indicate success.
           })
@@ -461,10 +461,10 @@ Last update: 2018sep22
       },
 
       uploadDefaults(uid) {
-        console.log('uploadDefaults() called')
-        status.start(this, 'Uploading defaults...')
+        console.log('uploadDefaults() called')     
         rpcs.upload('upload_defaults', [uid], {}, '.xlsx')
           .then(response => {
+            status.start(this, 'Uploading defaults...')
             this.updateProjectSummaries(uid) // Update the project summaries
             status.succeed(this, 'Defaults uploaded to project') // Indicate success.
           })


### PR DESCRIPTION
The upload buttons in the Projects page project table and the upload button in the Inputs page no longer trigger a spinner right away, but the spinner is only triggered after the user picks a file.