### PR TITLE
Fix export results

### DIFF
--- a/nutrition/model.py
+++ b/nutrition/model.py
@@ -86,8 +86,7 @@ class Model(sc.prettyobj):
     def _track_rates(self):
         """ Rates defined as total deaths per 1000 live births.
          This is calculated per year with the cumulative deaths and births,
-         so the final element will be total rates over the simulation period.
-         Note: for now, only calculating final entry since this is all that is required """
+         so the final element will be total rates over the simulation period. """
         self.child_mortrate[self.year] = 1000 * np.sum(self.child_deaths) / np.sum(self.annual_births)
         self.pw_mortrate[self.year] = 1000 * np.sum(self.pw_deaths) / np.sum(self.annual_births)
 
@@ -125,7 +124,7 @@ class Model(sc.prettyobj):
                 self.prog_info.adjust_covs(self.pops, year)
             self.integrate()
             self._track()
-        self._track_rates()
+            self._track_rates()
 
     def _apply_prog_covs(self):
         # update populations

--- a/nutrition/results.py
+++ b/nutrition/results.py
@@ -12,7 +12,7 @@ class ScenResult(sc.prettyobj):
         self.pops = self.model.pops
         self.mult = mult
         self.obj = obj
-        self.years = range(model.t[0], model.t[1]+1)
+        self.years = list(range(model.t[0], model.t[1]+1))
         self.uid = sc.uuid()
         self.created = sc.now()
         self.modified = sc.now()
@@ -122,7 +122,7 @@ def write_results(results, projname=None, filename=None, folder=None):
     sheetnames = ['Outcomes', 'Budget & coverage']
     alldata = []
     allformats = []
-    years = list(results[0].years)
+    years = results[0].years
     nullrow = [''] * len(years)
 
     ### Outcomes sheet


### PR DESCRIPTION
Two things have been fixed by this PR:
* The crashes caused by `range()` not giving a list in Python 3 has been fixed by wrapping the critical code with `list()` to do the conversion, which should also work even in Python 2 because `list()` on a list is the same thing.
* The data is now saved for child and pregnant women mortality rates for every year rather than just the last year.