### PR TITLE
Fix not polling

### DIFF
--- a/client/src/app/GeospatialPage.vue
+++ b/client/src/app/GeospatialPage.vue
@@ -434,8 +434,8 @@ Last update: 2018dec07
       doTaskPolling(checkAllTasks) {
         // Flag that we're polling.
         this.pollingTasks = true
-		
-		// If we there are some optimization summaries...
+
+        // If we there are some optimization summaries...
         if (this.geoSummaries.length > 0) {         
           // Do the polling of the task states.
           this.pollAllTaskStates(checkAllTasks)

--- a/client/src/app/OptimizationsPage.vue
+++ b/client/src/app/OptimizationsPage.vue
@@ -411,8 +411,8 @@ Last update: 2018dec07
       doTaskPolling(checkAllTasks) {
         // Flag that we're polling.
         this.pollingTasks = true
-		
-		// If we there are some optimization summaries...
+
+        // If we there are some optimization summaries...
         if (this.optimSummaries.length > 0) {       
           // Do the polling of the task states.
           this.pollAllTaskStates(checkAllTasks)


### PR DESCRIPTION
This PR fixes a problem that was happening on both the optimizations and geospatial optimizations pages.  On both these pages, if you had an empty list of optimizations, if you then added a new optimization and immediately ran it afterwards, it would run, but task polling would fail to start.  This was fixed by having the case of the empty list properly checked.  Note: This fix needs to be propagated to other Optima webapps.