### PR TITLE
Make cost effectiveness table optional and not generated by default

### DIFF
--- a/client/src/app/OptimizationsPage.vue
+++ b/client/src/app/OptimizationsPage.vue
@@ -57,6 +57,11 @@ Last update: 2019jan10
         </table>
 
         <div>
+            <input type="checkbox" id="costeff_checkbox" v-model="calculateCostEff"/>
+            <label for="costeff_checkbox">Perform intervention cost-effectiveness analysis</label>
+        </div>
+
+        <div>
           <button class="btn" :disabled="!optimsLoaded" @click="addOptimModal()">Add optimization</button>
         </div>
       </div>
@@ -88,7 +93,7 @@ Last update: 2019jan10
       </div>
 
       <br>
-      <div v-if="table">
+      <div v-if="hasTable">
         <help reflink="cost-effectiveness" label="Program cost-effectiveness"></help>
         <div class="calib-graphs" style="display:inline-block; text-align:right; overflow:auto">
           <table class="table table-bordered table-hover table-striped">
@@ -251,6 +256,8 @@ Last update: 2019jan10
         },
         figscale: 1.0,
         hasGraphs: false,
+        calculateCostEff: false,
+        hasTable: false,
         table: [],
       }
     },
@@ -695,8 +702,9 @@ Last update: 2019jan10
       plotOptimization(optimSummary) {
         console.log('plotOptimization() called')
         status.start(this)
-        rpcs.rpc('plot_optimization', [this.projectID, optimSummary.serverDatastoreId])
+        rpcs.rpc('plot_optimization', [this.projectID, optimSummary.serverDatastoreId, this.calculateCostEff])
           .then(response => {
+            this.hasTable = this.calculateCostEff
             this.table = response.data.table
             this.makeGraphs(response.data.graphs)
             this.displayResultName = optimSummary.name

--- a/client/src/app/ScenariosPage.vue
+++ b/client/src/app/ScenariosPage.vue
@@ -57,6 +57,11 @@ Last update: 2019jan09
         </table>
 
         <div>
+            <input type="checkbox" id="costeff_checkbox" v-model="calculateCostEff"/>
+            <label for="costeff_checkbox">Perform intervention cost-effectiveness analysis</label>
+        </div>
+
+        <div>
           <button class="btn __green" :disabled="!scenariosLoaded" @click="runScens()">Run scenarios</button>
           <button class="btn __blue"  :disabled="!scenariosLoaded" @click="addScenModal('coverage')">Add coverage scenario</button>
           <button class="btn __blue"  :disabled="!scenariosLoaded" @click="addScenModal('budget')">Add budget scenario</button>
@@ -94,7 +99,7 @@ Last update: 2019jan09
       </div>
 
       <br>
-      <div v-if="table">
+      <div v-if="hasTable">
         <help reflink="cost-effectiveness" label="Program cost-effectiveness"></help>
         <div class="calib-graphs" style="display:inline-block; text-align:right; overflow:auto">
           <table class="table table-bordered table-hover table-striped">
@@ -239,6 +244,8 @@ Last update: 2019jan09
         },
         figscale: 1.0,
         hasGraphs: false,
+        calculateCostEff: false,
+        hasTable: false,
         table: [],
       }
     },
@@ -462,8 +469,9 @@ Last update: 2019jan09
         status.start(this)
         rpcs.rpc('set_scen_info', [this.projectID, this.scenSummaries]) // Make sure they're saved first
           .then(response => {
-            rpcs.rpc('run_scens', [this.projectID]) // Go to the server to get the results
+            rpcs.rpc('run_scens', [this.projectID, true, this.calculateCostEff]) // Go to the server to get the results
               .then(response => {
+                this.hasTable = this.calculateCostEff
                 this.table = response.data.table
                 this.makeGraphs(response.data.graphs)
                 status.succeed(this, '') // Success message in graphs function

--- a/client/src/sass/_cards.scss
+++ b/client/src/sass/_cards.scss
@@ -42,7 +42,7 @@
   label {
     font-size: $font-size-base;
     font-weight: $font-weight-normal;
-    color: $dark-gray;
+    color: $black-color;
     margin-bottom: 0px;
     i {
       font-size: $font-paragraph;

--- a/nutrition_app/rpcs.py
+++ b/nutrition_app/rpcs.py
@@ -931,15 +931,18 @@ def reformat_costeff(costeff):
 
 
 @RPC()
-def run_scens(project_id, doplot=True):
+def run_scens(project_id, doplot=True, do_costeff=False):
     
     print('Running scenarios...')
     proj = load_project(project_id, die=True)
     proj.run_scens()
-    
-    # Get cost-effectiveness table
-    costeff = nu.get_costeff(project=proj, results=proj.result('scens'))
-    table = reformat_costeff(costeff)
+
+    if do_costeff:
+        # Get cost-effectiveness table
+        costeff = nu.get_costeff(project=proj, results=proj.result('scens'))
+        table = reformat_costeff(costeff)
+    else:
+        table = []
     
     # Get graphs
     graphs = []
@@ -950,6 +953,7 @@ def run_scens(project_id, doplot=True):
                 ax.set_facecolor('none')
             graph_dict = sw.mpld3ify(fig, jsonify=False)
             graphs.append(graph_dict)
+            pl.close(fig)
             print('Converted figure %s of %s' % (f+1, len(figs)))
         
     # Store results in cache
@@ -1060,7 +1064,7 @@ def get_default_optim(project_id, model_name=None):
 
 
 @RPC()
-def plot_optimization(project_id, cache_id):
+def plot_optimization(project_id, cache_id, do_costeff=False):
     proj = load_project(project_id, die=True)
     proj = retrieve_results(proj)
     figs = proj.plot(key=cache_id, optim=True) # Only plot allocation
@@ -1070,11 +1074,15 @@ def plot_optimization(project_id, cache_id):
             ax.set_facecolor('none')
         graph_dict = sw.mpld3ify(fig, jsonify=False)
         graphs.append(graph_dict)
+        pl.close(fig)
         print('Converted figure %s of %s' % (f+1, len(figs)))
     
     # Get cost-effectiveness table
-    costeff = nu.get_costeff(project=proj, results=proj.result(cache_id))
-    table = reformat_costeff(costeff)
+    if do_costeff:
+        costeff = nu.get_costeff(project=proj, results=proj.result(cache_id))
+        table = reformat_costeff(costeff)
+    else:
+        table = []
     
     return {'graphs':graphs, 'table':table}
 


### PR DESCRIPTION
This PR adds a checkbox in the FE to optionally generate the cost-effectiveness table. Examples shown below

![image](https://user-images.githubusercontent.com/755796/52606261-f6b7bd00-2eac-11e9-9f8b-cd6224a735f6.png)

![image](https://user-images.githubusercontent.com/755796/52606271-fcad9e00-2eac-11e9-98f6-ad578fdb39f5.png)

If the box is checked, then clicking 'Run scenarios' (scenarios page) or 'Plot results' (optimization page) will generate and show the cost effectiveness table, otherwise it will not be generated or shown. Not showing the table greatly speeds up showing the results because computing the table is quite computationally expensive